### PR TITLE
Add gettext and pbench-uperf to workload container image

### DIFF
--- a/scale-ci-workload/Dockerfile
+++ b/scale-ci-workload/Dockerfile
@@ -21,9 +21,9 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/anaconda.target.wants/* && \
     yum --skip-broken clean all && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo && \
-    yum --skip-broken --enablerepo=ndokos-pbench install -y configtools openssh-clients openssh-server pbench-agent jq \
-    iproute sysvinit-tools pbench-sysstat git ansible which bind-utils blktrace ethtool iotop iptables-services perf wget initscripts && \
-    yum clean all && \
+    yum --skip-broken --enablerepo=ndokos-pbench install -y configtools openssh-clients openssh-server pbench-agent pbench-uperf jq \
+    iproute sysvinit-tools pbench-sysstat git ansible which bind-utils blktrace ethtool iotop iptables-services perf wget initscripts \
+    gettext && yum clean all && \
     sed -i "s/#Port 22/Port 2022/" /etc/ssh/sshd_config && \
     chmod g=u /etc/passwd && \
     chmod 600 /root/.ssh/config && \


### PR DESCRIPTION
gettext rpm provides `envsubst` which can be used to substitute environment variables with their value.
pbench-uperf is required on the workload container for the network tests