### PR TITLE
Added cmds to install pip2.7 boto3 rbd and flask python packages to allow running python cluster-loader from container

### DIFF
--- a/scale-ci-workload/Dockerfile
+++ b/scale-ci-workload/Dockerfile
@@ -43,6 +43,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     yum --skip-broken --enablerepo=copr:copr.fedorainfracloud.org:ndokos:pbench install -y configtools openssh-clients openssh-server pbench-agent pbench-uperf pbench-fio jq \
     iproute sysvinit-tools pbench-sysstat git ansible which bind-utils blktrace ethtool iotop iptables-services perf wget initscripts \
     gettext python-requests && yum install -y python36-setuptools && easy_install-3.6 pip && pip3 install requests && yum clean all && \
+    easy_install-2.7 pip && pip2.7 install boto3 && yum install -y python-rbd python-flask && \
     sed -i "s/#Port 22/Port 2022/" /etc/ssh/sshd_config && \
     chmod g=u /etc/passwd && \
     chmod 600 /root/.ssh/config && \


### PR DESCRIPTION
Some scripts in SVT repo like concurrent builds and concurrent scale up need to run python cluster-loader.  In order to run these scripts from the scale-ci-workload container, we need to install these python packages:

    easy_install-2.7 pip 
    pip2.7 install boto3 
    yum install -y python-rbd python-flask 

