### PR TITLE
Cluster loader tag

### DIFF
--- a/scale-ci-workload/Dockerfile
+++ b/scale-ci-workload/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p $GOPATH/src/github.com/openshift-scale/perf-analyzer && \
     go get -d -v ./... && cd $GOPATH/src/github.com/openshift-scale/perf-analyzer && make
 
 # Origin-tests for oc/openshift-tests
-FROM quay.io/openshift/origin-tests:latest as origintests
+FROM quay.io/openshift/origin-tests:4.3 as origintests
 
 FROM centos:7
 


### PR DESCRIPTION
Some tests are not available in the latest openshift-tests container's tag.

With the latest tag
```
$ podman run -v ~/.kube/config:/root/.kube/config:z --rm  -it  quay.io/openshift/origin-tests:latest  /bin/bash -c 'export KUBECONFIG=/root/.kube/config && openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"'
I0302 12:06:59.132768       2 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
error: no test exists with that name
```

With the 4.3 tag
```
$ podman run -v ~/.kube/config:/root/.kube/config:z --rm  -it  quay.io/openshift/origin-tests:4.3  /bin/bash -c 'export KUBECONFIG=/root/.kube/config && openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"'
Mar  2 12:07:05.746: INFO: >>> kubeConfig: /root/.kube/config
Mar  2 12:07:05.748: INFO: >>> kubeConfig: /root/.kube/config
...
```
