### PR TITLE
Added run label to etcd-perf image

### DIFF
--- a/etcd-perf/Dockerfile
+++ b/etcd-perf/Dockerfile
@@ -2,6 +2,8 @@ FROM centos:8
 
 MAINTAINER Red Hat OpenShift Performance and Scale
 
+LABEL RUN="podman run --volume /var/lib/etcd:/var/lib/etcd:Z IMAGE"
+
 RUN yum install epel-release -y && yum install jq fio -y && yum clean all && rm -rf /var/cache/yum
 
 COPY run.sh /tmp/run.sh


### PR DESCRIPTION
Added label `RUN` so that we a have recommended way to run the image that can be consumed in a simple manner.

This way, running:
```
podman container runlabel run quay.io/openshift-scale/etcd-perf
```

Automatically runs:
```
podman run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale/etcd-perf
```

Or whatever other command can be specified in the future in the `RUN` label.

More information here: https://podman.io/blogs/2018/12/03/podman-runlabel.html