### PR TITLE
Etcd perf improvements

### DIFF
--- a/etcd-perf/Dockerfile
+++ b/etcd-perf/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 MAINTAINER Red Hat OpenShift Performance and Scale
 

--- a/etcd-perf/Makefile
+++ b/etcd-perf/Makefile
@@ -1,0 +1,16 @@
+
+
+REGISTRY?=quay.io
+ORG?=openshift-scale
+REPO?=etcd-perf
+
+IMAGE=$(REGISTRY)/$(ORG)/$(REPO)
+
+all: build push
+
+build:
+	podman build --platform=linux/amd64,linux/arm64,linux/ppc64le --manifest=$(IMAGE):latest .
+push:
+	podman manifest push $(IMAGE):latest $(IMAGE):latest
+
+.PHONY: all build push

--- a/etcd-perf/run.sh
+++ b/etcd-perf/run.sh
@@ -7,7 +7,7 @@ mkdir -p /var/lib/etcd
 
 # Run fio
 echo "---------------------------------------------------------------- Running fio ---------------------------------------------------------------------------"
-fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd --size=22m --bs=2300 --name=etcd_perf --output-format=json | tee /tmp/fio.out
+fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd --size=100m --bs=7500 --name=etcd_perf --output-format=json --runtime=60 --time_based=1 | tee /tmp/fio.out
 echo "--------------------------------------------------------------------------------------------------------------------------------------------------------"
 
 # Scrape the fio output for p99 of fsync in ns
@@ -15,8 +15,8 @@ fsync=$(cat /tmp/fio.out | jq '.jobs[0].sync.lat_ns.percentile["99.000000"]')
 echo "99th percentile of fsync is $fsync ns"
 
 # Compare against the recommended value
-if [[ $fsync -ge 10000000 ]]; then
-  echo "99th percentile of the fsync is greater than the recommended value which is 10 ms, faster disks are recommended to host etcd for better performance"
+if [[ $fsync -ge 20000000 ]]; then
+  echo "99th percentile of the fsync is greater than the recommended value which is 20 ms, faster disks are recommended to host etcd for better performance"
 else
-  echo "99th percentile of the fsync is within the recommended threshold - 10 ms, the disk can be used to host etcd"
+  echo "99th percentile of the fsync is within the recommended threshold: - 20 ms, the disk can be used to host etcd"
 fi

--- a/etcd-perf/run.sh
+++ b/etcd-perf/run.sh
@@ -12,11 +12,11 @@ echo "--------------------------------------------------------------------------
 
 # Scrape the fio output for p99 of fsync in ns
 fsync=$(cat /tmp/fio.out | jq '.jobs[0].sync.lat_ns.percentile["99.000000"]')
-echo "99th percentile of fsync is $fsync ns"
+echo "INFO: 99th percentile of fsync is $fsync ns"
 
 # Compare against the recommended value
 if [[ $fsync -ge 20000000 ]]; then
-  echo "99th percentile of the fsync is greater than the recommended value which is ${fsync} ns > 20 ms, faster disks are recommended to host etcd for better performance"
+  echo "WARN: 99th percentile of the fsync is greater than the recommended value which is ${fsync} ns > 20 ms, faster disks are recommended to host etcd for better performance"
 else
-  echo "99th percentile of the fsync is within the recommended threshold: - 20 ms, the disk can be used to host etcd"
+  echo "INFO: 99th percentile of the fsync is within the recommended threshold: - 20 ms, the disk can be used to host etcd"
 fi

--- a/etcd-perf/run.sh
+++ b/etcd-perf/run.sh
@@ -7,7 +7,7 @@ mkdir -p /var/lib/etcd
 
 # Run fio
 echo "---------------------------------------------------------------- Running fio ---------------------------------------------------------------------------"
-fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd --size=100m --bs=7500 --name=etcd_perf --output-format=json --runtime=60 --time_based=1 | tee /tmp/fio.out
+fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd --size=100m --bs=8000 --name=etcd_perf --output-format=json --runtime=60 --time_based=1 | tee /tmp/fio.out
 echo "--------------------------------------------------------------------------------------------------------------------------------------------------------"
 
 # Scrape the fio output for p99 of fsync in ns
@@ -16,7 +16,7 @@ echo "99th percentile of fsync is $fsync ns"
 
 # Compare against the recommended value
 if [[ $fsync -ge 20000000 ]]; then
-  echo "99th percentile of the fsync is greater than the recommended value which is 20 ms, faster disks are recommended to host etcd for better performance"
+  echo "99th percentile of the fsync is greater than the recommended value which is ${fsync} ns > 20 ms, faster disks are recommended to host etcd for better performance"
 else
   echo "99th percentile of the fsync is within the recommended threshold: - 20 ms, the disk can be used to host etcd"
 fi


### PR DESCRIPTION
Increase block size to 8000 bytes. Some context at https://docs.google.com/document/d/1zq1IhIQMK7RO68V41OdVZAyrwVwriyZ-KjHsu1PTjtE/edit and  https://docs.google.com/document/d/1vWy_P8YRuC8H8NEpFdQAs7SZsJqt7z4rBqzEtD_75Eo/edit

Use runtime based test rather than the fixed size of 22m and update pass/fail criteria to 20ms to be aligned with the information from the above documents.

And last but not least, adding a makefile to ease multi-arch builds