### PR TITLE
Include s390x arch

### DIFF
--- a/etcd-perf/Dockerfile
+++ b/etcd-perf/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 MAINTAINER Red Hat OpenShift Performance and Scale
 
 LABEL RUN="podman run --volume /var/lib/etcd:/var/lib/etcd:Z IMAGE"
 
-RUN yum install epel-release -y && yum install jq fio -y && yum clean all && rm -rf /var/cache/yum
+RUN dnf install jq fio -y && dnf clean all && rm -rf /var/cache/dnf
 
 COPY run.sh /tmp/run.sh
 

--- a/etcd-perf/Makefile
+++ b/etcd-perf/Makefile
@@ -9,7 +9,7 @@ IMAGE=$(REGISTRY)/$(ORG)/$(REPO)
 all: build push
 
 build:
-	podman build --platform=linux/amd64,linux/arm64,linux/ppc64le --manifest=$(IMAGE):latest .
+	podman build --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --manifest=$(IMAGE):latest .
 push:
 	podman manifest push $(IMAGE):latest $(IMAGE):latest
 


### PR DESCRIPTION
Adding s390x architecture. I had to update the centos version since this arch wasn't available in the previous one.
Also, removing the EPEL references, since FIO and jq are available in the default OS repos

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>